### PR TITLE
Added announce command

### DIFF
--- a/src/main/java/com/honiism/discord/lemi/commands/slash/handler/SlashCmdManager.java
+++ b/src/main/java/com/honiism/discord/lemi/commands/slash/handler/SlashCmdManager.java
@@ -41,6 +41,7 @@ import com.honiism.discord.lemi.commands.slash.main.Donate;
 import com.honiism.discord.lemi.commands.slash.main.Help;
 import com.honiism.discord.lemi.commands.slash.main.Ping;
 import com.honiism.discord.lemi.commands.slash.staff.admins.AdminsTopLevel;
+import com.honiism.discord.lemi.commands.slash.staff.admins.Announce;
 import com.honiism.discord.lemi.commands.slash.staff.admins.ShardRestart;
 import com.honiism.discord.lemi.commands.slash.staff.admins.UserBan;
 import com.honiism.discord.lemi.commands.slash.staff.dev.Compile;
@@ -110,11 +111,13 @@ public class SlashCmdManager {
         ManageItems manageItemsCmd = new ManageItems();
         ViewItems viewItemsCmd = new ViewItems();
         SetDebug setDebugCmd = new SetDebug();
+        Announce announceCmd = new Announce();
 
         DevTopLevel devTopLevelCmd = new DevTopLevel(modifyAdminsCmd, modifyModsCmd, shutdownCmd, compileCmd,
                 manageItemsCmd, setDebugCmd);
 
-        AdminsTopLevel adminsTopLevelCmd = new AdminsTopLevel(userBanCmd, shardRestartCmd, embedCmd, resetCurrDataCmd);
+        AdminsTopLevel adminsTopLevelCmd = new AdminsTopLevel(userBanCmd, shardRestartCmd, embedCmd,
+                resetCurrDataCmd, announceCmd);
 
         ModsTopLevel modsTopLevelCmd = new ModsTopLevel(testCmd, guildListCmd, shardStatusCmd,
                 addCurrProfileCmd, modifyBalCmd, modifyInvCmd, viewItemsCmd);
@@ -160,6 +163,7 @@ public class SlashCmdManager {
         allSlashCmds.add(manageItemsCmd);
         allSlashCmds.add(viewItemsCmd);
         allSlashCmds.add(setDebugCmd);
+        allSlashCmds.add(announceCmd);
 
         allSlashCmds.add(devTopLevelCmd);
         allSlashCmds.add(adminsTopLevelCmd);

--- a/src/main/java/com/honiism/discord/lemi/commands/slash/staff/admins/AdminsTopLevel.java
+++ b/src/main/java/com/honiism/discord/lemi/commands/slash/staff/admins/AdminsTopLevel.java
@@ -35,13 +35,15 @@ public class AdminsTopLevel extends SlashCmd {
     private ShardRestart shardRestartSubCmd;
     private Embed embedGroup;
     private ResetCurrData resetCurrDataCmd;
+    private Announce announceCmd;
 
     public AdminsTopLevel(UserBan userBanGroup, ShardRestart shardRestartGroup, Embed embedGroup,
-                          ResetCurrData resetCurrData) {
+                          ResetCurrData resetCurrDataCmd, Announce announceCmd) {
         this.userBanGroup = userBanGroup;
         this.shardRestartSubCmd = shardRestartGroup;
         this.embedGroup = embedGroup;
-        this.resetCurrDataCmd = resetCurrData;
+        this.resetCurrDataCmd = resetCurrDataCmd;
+        this.announceCmd = announceCmd;
 
         setCommandData(Commands.slash("admins", "Commands for the admins of Lemi the discord bot.")
                 .addSubcommands(
@@ -49,7 +51,10 @@ public class AdminsTopLevel extends SlashCmd {
                                 .addOptions(this.shardRestartSubCmd.getOptions()),
 
                         new SubcommandData(this.resetCurrDataCmd.getName(), this.resetCurrDataCmd.getDesc())
-                                .addOptions(this.resetCurrDataCmd.getOptions())
+                                .addOptions(this.resetCurrDataCmd.getOptions()),
+
+                        new SubcommandData(this.announceCmd.getName(), this.announceCmd.getDesc())
+                                .addOptions(this.announceCmd.getOptions())
                 )
                 .addSubcommandGroups(
                         new SubcommandGroupData(this.userBanGroup.getName(), this.userBanGroup.getDesc())
@@ -91,6 +96,10 @@ public class AdminsTopLevel extends SlashCmd {
 
                 case "resetcurrdata":
                     this.resetCurrDataCmd.action(event);
+                    break;
+
+                case "announce":
+                    this.announceCmd.action(event);
             }
         }
     }

--- a/src/main/java/com/honiism/discord/lemi/commands/slash/staff/admins/Announce.java
+++ b/src/main/java/com/honiism/discord/lemi/commands/slash/staff/admins/Announce.java
@@ -1,0 +1,153 @@
+/**
+ * Copyright (C) 2022 Honiism
+ * 
+ * This file is part of Lemi-Bot.
+ * 
+ * Lemi-Bot is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Lemi-Bot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Lemi-Bot. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.honiism.discord.lemi.commands.slash.staff.admins;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.function.Consumer;
+
+import com.honiism.discord.lemi.commands.handler.CommandCategory;
+import com.honiism.discord.lemi.commands.handler.UserCategory;
+import com.honiism.discord.lemi.commands.slash.handler.SlashCmd;
+import com.honiism.discord.lemi.utils.misc.CustomEmojis;
+import com.honiism.discord.lemi.utils.misc.Tools;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.ChannelType;
+import net.dv8tion.jda.api.entities.GuildChannel;
+import net.dv8tion.jda.api.entities.Message;
+import net.dv8tion.jda.api.entities.NewsChannel;
+import net.dv8tion.jda.api.entities.Role;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.commands.OptionMapping;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+
+public class Announce extends SlashCmd {
+
+    private HashMap<Long, Long> delay = new HashMap<>();
+    private long timeDelayed;
+
+    public Announce() {
+        setCommandData(Commands.slash("announce", "Makes an announcement.")
+                .addOption(OptionType.STRING, "message", "The message you want to announce.", true)
+                .addOption(OptionType.CHANNEL, "channel", "The channel where you want to announce.", true)
+                .addOption(OptionType.BOOLEAN, "publishable", "Toggle if Lemi should publish this message.", false)
+                .addOption(OptionType.ROLE, "role", "Role to ping while announcing.", false)
+        );
+
+        setUsage("/admins announce <message> <channel> [role]");
+        setCategory(CommandCategory.ADMINS);
+        setUserCategory(UserCategory.ADMINS);
+        setUserPerms(new Permission[] {Permission.ADMINISTRATOR});
+        setBotPerms(new Permission[] {Permission.ADMINISTRATOR});
+        
+    }
+
+    @Override
+    public void action(SlashCommandInteractionEvent event) {
+        InteractionHook hook = event.getHook();
+        User author = event.getUser();
+
+        if (delay.containsKey(author.getIdLong())) {
+            timeDelayed = System.currentTimeMillis() - delay.get(author.getIdLong());
+        } else {
+            timeDelayed = (10 * 1000);
+        }
+            
+        if (timeDelayed >= (10 * 1000)) {        
+            if (delay.containsKey(author.getIdLong())) {
+                delay.remove(author.getIdLong());
+            }
+        
+            delay.put(author.getIdLong(), System.currentTimeMillis());
+
+            GuildChannel guildChannel = event.getOption("channel", OptionMapping::getAsGuildChannel);
+
+            if (!guildChannel.getType().equals(ChannelType.NEWS)) {
+                hook.sendMessage(":grapes: You can only send announcement messages in news channels.").queue();
+                return;
+            }
+            
+            String announceMsg = event.getOption("message", OptionMapping::getAsString);
+
+            EmbedBuilder announceEmbed = new EmbedBuilder()
+                .setTitle(":tulip: Ding ding!")
+                .setDescription(":sunflower: An announcement has been made!\r\n" + "-\r\n" + "> " + announceMsg)
+                .setAuthor(author.getAsTag(), null, author.getEffectiveAvatarUrl())
+                .setThumbnail(event.getGuild().getSelfMember().getEffectiveAvatarUrl())
+                .setColor(0xffd1dc)
+                .setFooter("End of announcement!")
+                .setTimestamp(Instant.now());
+
+            NewsChannel newsChannel = event.getJDA().getNewsChannelById(guildChannel.getIdLong());
+
+            Role roleToMention = event.getOption("role", OptionMapping::getAsRole);
+            boolean doCrosspot = event.getOption("publishable", false, OptionMapping::getAsBoolean);
+
+            if (roleToMention != null) {
+                newsChannel.sendMessage(CustomEmojis.EXCLAMATION_MARK + " " + roleToMention.getAsMention())
+                    .setEmbeds(announceEmbed.build())
+                    .queue((msg) -> {
+                        if (doCrosspot) {
+                            crosspostMessage(msg,
+                                    (success) -> hook.sendMessage(":seedling: Successfully published announcement message.").queue(),
+                                    (error) -> hook.sendMessage(":blueberries: Unable to publish announcement message").queue());
+                            return;
+                        }
+
+                        hook.sendMessage(":hibiscus: Announced the message!").queue();
+                    });
+                return;
+            }
+
+            newsChannel.sendMessageEmbeds(announceEmbed.build())
+                .queue((msg) -> {
+                    if (doCrosspot) {
+                        crosspostMessage(msg,
+                                (success) -> hook.sendMessage(":seedling: Successfully published announcement message.").queue(),
+                                (error) -> hook.sendMessage(":blueberries: Unable to publish announcement message").queue());
+                        return;
+                    }
+
+                    hook.sendMessage(":hibiscus: Announced the message!").queue();
+                }); 
+            
+        } else {
+            String time = Tools.secondsToTime(((10 * 1000) - timeDelayed) / 1000);
+                
+            EmbedBuilder cooldownMsgEmbed = new EmbedBuilder()
+                .setDescription("‧₊੭ :cherries: CHILL! ♡ ⋆｡˚\r\n" 
+                        + "˚⊹ ˚︶︶꒷︶꒷꒦︶︶꒷꒦︶ ₊˚⊹.\r\n"
+                        + author.getAsMention() 
+                        + ", you can use this command again in `" + time + "`.")
+                .setColor(0xffd1dc);
+                
+            hook.sendMessageEmbeds(cooldownMsgEmbed.build()).queue();
+        }
+    }
+
+    private void crosspostMessage(Message message, Consumer<Message> success, Consumer<Throwable> failure) {
+        message.crosspost().queue(success, failure);
+    }
+}

--- a/src/main/java/com/honiism/discord/lemi/commands/slash/staff/admins/Announce.java
+++ b/src/main/java/com/honiism/discord/lemi/commands/slash/staff/admins/Announce.java
@@ -56,7 +56,7 @@ public class Announce extends SlashCmd {
                 .addOption(OptionType.ROLE, "role", "Role to ping while announcing.", false)
         );
 
-        setUsage("/admins announce <message> <channel> [role]");
+        setUsage("/admins announce <message> <channel> [publishable] [role]");
         setCategory(CommandCategory.ADMINS);
         setUserCategory(UserCategory.ADMINS);
         setUserPerms(new Permission[] {Permission.ADMINISTRATOR});


### PR DESCRIPTION
## 🍙 Pull Request Etiquette

- [x] I have checked the PRs and branches for this feature/bug fix.
- [x] I have read the [contributing manual](https://github.com/honiism/lemi-bot/wiki/Contributing)

## 🎀 Changes

### 🍰 Description
Added announce command for admins (`/admins announce <message> <channel> [publishable] [role]`). This will give the ability to announce in any news channel and automatically crosspost the message.

### 🌷 Details
- Added announce command.
- Registered announce command.
- Renamed resetCurrData to resetCurrDataCmd.
- Closes issue: N/A (for this [card](https://github.com/honiism/lemi-bot/projects/1#card-78524230))

![image](https://user-images.githubusercontent.com/91908168/156607231-d2b02319-2ae8-4ce1-b240-3a674c0117b4.png)
![image](https://user-images.githubusercontent.com/91908168/156607373-0fd97574-cf4e-438d-91ce-265980ee52f1.png)