### PR TITLE
Added dashboard command

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,13 +41,7 @@
     <dependency>
         <groupId>org.json</groupId>
         <artifactId>json</artifactId>
-        <version>20210307</version>
-    </dependency>
-    
-    <dependency>
-        <groupId>com.vdurmont</groupId>
-        <artifactId>emoji-java</artifactId>
-        <version>5.1.1</version>
+        <version>20211205</version>
     </dependency>
     
     <dependency>
@@ -81,27 +75,15 @@
     </dependency>
 
     <dependency>
-        <groupId>junit</groupId>
-        <artifactId>junit</artifactId>
-        <version>4.13.1</version>
-    </dependency>
-
-    <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>31.0.1-jre</version>
     </dependency>
-    
+
     <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-text</artifactId>
-        <version>1.9</version>
-    </dependency>
-    
-    <dependency>
-        <groupId>org.apache.commons</groupId>
-        <artifactId>commons-lang3</artifactId>
-        <version>3.12.0</version>
+        <groupId>com.github.oshi</groupId>
+        <artifactId>oshi-core</artifactId>
+        <version>5.3.4</version>
     </dependency>
 </dependencies>
 

--- a/src/main/java/com/honiism/discord/lemi/commands/slash/handler/SlashCmdManager.java
+++ b/src/main/java/com/honiism/discord/lemi/commands/slash/handler/SlashCmdManager.java
@@ -52,6 +52,7 @@ import com.honiism.discord.lemi.commands.slash.staff.dev.ModifyMods;
 import com.honiism.discord.lemi.commands.slash.staff.dev.SetDebug;
 import com.honiism.discord.lemi.commands.slash.staff.dev.Shutdown;
 import com.honiism.discord.lemi.commands.slash.staff.mods.AddCurrProfile;
+import com.honiism.discord.lemi.commands.slash.staff.mods.Dashboard;
 import com.honiism.discord.lemi.commands.slash.staff.mods.GuildList;
 import com.honiism.discord.lemi.commands.slash.staff.mods.ModifyBal;
 import com.honiism.discord.lemi.commands.slash.staff.mods.ModifyInv;
@@ -112,6 +113,7 @@ public class SlashCmdManager {
         ViewItems viewItemsCmd = new ViewItems();
         SetDebug setDebugCmd = new SetDebug();
         Announce announceCmd = new Announce();
+        Dashboard dashboardCmd = new Dashboard();
 
         DevTopLevel devTopLevelCmd = new DevTopLevel(modifyAdminsCmd, modifyModsCmd, shutdownCmd, compileCmd,
                 manageItemsCmd, setDebugCmd);
@@ -120,7 +122,7 @@ public class SlashCmdManager {
                 resetCurrDataCmd, announceCmd);
 
         ModsTopLevel modsTopLevelCmd = new ModsTopLevel(testCmd, guildListCmd, shardStatusCmd,
-                addCurrProfileCmd, modifyBalCmd, modifyInvCmd, viewItemsCmd);
+                addCurrProfileCmd, modifyBalCmd, modifyInvCmd, viewItemsCmd, dashboardCmd);
 
         CurrencyTopLevel currencyTopLevelCmd = new CurrencyTopLevel(balanceCmd, inventoryCmd, bankrobCmd, begCmd,
                 cookCmd);
@@ -164,6 +166,7 @@ public class SlashCmdManager {
         allSlashCmds.add(viewItemsCmd);
         allSlashCmds.add(setDebugCmd);
         allSlashCmds.add(announceCmd);
+        allSlashCmds.add(dashboardCmd);
 
         allSlashCmds.add(devTopLevelCmd);
         allSlashCmds.add(adminsTopLevelCmd);

--- a/src/main/java/com/honiism/discord/lemi/commands/slash/staff/mods/Dashboard.java
+++ b/src/main/java/com/honiism/discord/lemi/commands/slash/staff/mods/Dashboard.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (C) 2022 Honiism
+ * 
+ * This file is part of Lemi-Bot.
+ * 
+ * Lemi-Bot is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Lemi-Bot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Lemi-Bot. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.honiism.discord.lemi.commands.slash.staff.mods;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.time.Instant;
+import java.util.HashMap;
+
+import com.honiism.discord.lemi.commands.handler.CommandCategory;
+import com.honiism.discord.lemi.commands.handler.UserCategory;
+import com.honiism.discord.lemi.commands.slash.handler.SlashCmd;
+import com.honiism.discord.lemi.utils.misc.Tools;
+
+import net.dv8tion.jda.api.EmbedBuilder;
+import net.dv8tion.jda.api.Permission;
+import net.dv8tion.jda.api.entities.User;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.interactions.InteractionHook;
+import net.dv8tion.jda.api.interactions.commands.build.Commands;
+import oshi.SystemInfo;
+import oshi.hardware.CentralProcessor;
+import oshi.hardware.HardwareAbstractionLayer;
+
+public class Dashboard extends SlashCmd {
+
+    private HashMap<Long, Long> delay = new HashMap<>();
+    private long timeDelayed;
+
+    public Dashboard() {
+        setCommandData(Commands.slash("dashboard", "View detials about Lemi's memory usage, uptime, etc."));
+        setUsage("/mods dashboard");
+        setCategory(CommandCategory.MODS);
+        setUserCategory(UserCategory.MODS);
+        setUserPerms(new Permission[] {Permission.MESSAGE_MANAGE});
+        setBotPerms(new Permission[] {Permission.MESSAGE_SEND, Permission.VIEW_CHANNEL, Permission.MESSAGE_HISTORY});
+        
+    }
+
+    @Override
+    public void action(SlashCommandInteractionEvent event) {
+        InteractionHook hook = event.getHook();
+        User author = event.getUser();
+        
+        if (delay.containsKey(author.getIdLong())) {
+            timeDelayed = System.currentTimeMillis() - delay.get(author.getIdLong());
+        } else {
+            timeDelayed = (10 * 1000);
+        }
+            
+        if (timeDelayed >= (10 * 1000)) {
+            if (delay.containsKey(author.getIdLong())) {
+                delay.remove(author.getIdLong());
+            }
+        
+            EmbedBuilder dashboardEmbed = new EmbedBuilder()
+                .setTitle(":tulip: Lemi Dashboard Info!")
+                .setThumbnail(event.getGuild().getSelfMember().getEffectiveAvatarUrl())
+                .addField(":sunflower: Memory info", getMemoryInfo(), false)
+                .addField(":seedling: OS Info", getOSInfo(), false)
+                .addField(":snowflake: CPU Info", getCPUInfo(), false)
+                .addField(":grapes: Uptime", getUptimeInfo(), false)
+                .setColor(0xffd1dc)
+                .setTimestamp(Instant.now());
+
+            hook.sendMessageEmbeds(dashboardEmbed.build()).queue();
+                
+        } else {
+            String time = Tools.secondsToTime(((10 * 1000) - timeDelayed) / 1000);
+                
+            EmbedBuilder cooldownMsgEmbed = new EmbedBuilder()
+                .setDescription("‧₊੭ :cherries: CHILL! ♡ ⋆｡˚\r\n" 
+                        + "˚⊹ ˚︶︶꒷︶꒷꒦︶︶꒷꒦︶ ₊˚⊹.\r\n"
+                        + author.getAsMention() 
+                        + ", you can use this command again in `" + time + "`.")
+                .setColor(0xffd1dc);
+                
+            hook.sendMessageEmbeds(cooldownMsgEmbed.build()).queue();
+        }
+    }
+
+    private String getMemoryInfo() {
+        long maxMemory = Runtime.getRuntime().maxMemory() / 1000;
+        long totalMemory = Runtime.getRuntime().totalMemory() / 1000;
+        long freeMemory = Runtime.getRuntime().freeMemory() / 1000;
+
+        String info = "- Max memory: `" + maxMemory + "`\r\n"
+                + "- Total memory: `" + totalMemory + "`\r\n"
+                + "- Free memory: `" + freeMemory + "`";
+
+        return info;
+    }
+
+    private String getOSInfo() {
+        String osName = System.getProperty("os.name");
+        String osVersion = System.getProperty("os.version");
+        String osArch = System.getProperty("os.arch");
+        
+        String info = "- OS Name: `" + osName + "`\r\n"
+                + "- OS Version: `" + osVersion + "`\r\n"
+                + "- OS architecture `" + osArch + "`";
+
+        return info;
+    }
+
+    private String getCPUInfo() {
+        SystemInfo systemInfo = new SystemInfo();
+        HardwareAbstractionLayer hardware = systemInfo.getHardware();
+        CentralProcessor processor = hardware.getProcessor();
+
+        CentralProcessor.ProcessorIdentifier processorIdentifier = processor.getProcessorIdentifier();
+
+        String vendor = processorIdentifier.getVendor();
+        String name = processorIdentifier.getName();
+        String id = processorIdentifier.getIdentifier();
+        String microArch = processorIdentifier.getMicroarchitecture();
+        
+        long frequencyHz = processorIdentifier.getVendorFreq();
+        double frequencyGHz = processorIdentifier.getVendorFreq() / 1000000000.0;
+
+        String info = "- Processor vendor: `" + vendor + "`\r\n"
+                + "- Processor name: `" + name + "`\r\n"
+                + "- Processor identifier: `" + id + "`\r\n"
+                + "- Processor microarchitecture: `" + microArch + "`\r\n"
+                + "- Frequency (Hz): `" + frequencyHz + "`\r\n"
+                + "- Frequency (GHz): `" + frequencyGHz + "`\r\n";
+
+        return info;
+    }
+
+    private String getUptimeInfo() {
+        RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+        
+        long uptime = runtimeMXBean.getUptime();
+        long uptimeSecs = uptime / 1000;
+        long hours = uptimeSecs / (60 * 60);
+        long minutes = (uptimeSecs / 60) - (hours * 60);
+        long seconds = uptimeSecs % 60;
+
+        String info = hours + " hour(s), " 
+                + minutes + " minute(s), " 
+                + seconds + " second(s).";
+        
+        return info;
+    }
+}

--- a/src/main/java/com/honiism/discord/lemi/commands/slash/staff/mods/ModsTopLevel.java
+++ b/src/main/java/com/honiism/discord/lemi/commands/slash/staff/mods/ModsTopLevel.java
@@ -37,10 +37,11 @@ public class ModsTopLevel extends SlashCmd {
     private ModifyBal modifyBalGroup;
     private ModifyInv modifyInvGroup;
     private ViewItems viewItemsCmd;
+    private Dashboard dashboardCmd;
 
     public ModsTopLevel(Test testSubCmd, GuildList guildListCmd, ShardStatus shardStatusCmd,
                         AddCurrProfile addCurrProfileCmd, ModifyBal modifyBalGroup,
-                        ModifyInv modifyInvGroup, ViewItems viewItemsCmd) {
+                        ModifyInv modifyInvGroup, ViewItems viewItemsCmd, Dashboard dashboardCmd) {
         this.shardStatusCmd = shardStatusCmd;
         this.testSubCmd = testSubCmd;
         this.guildListCmd = guildListCmd;
@@ -48,6 +49,7 @@ public class ModsTopLevel extends SlashCmd {
         this.modifyBalGroup = modifyBalGroup;
         this.modifyInvGroup = modifyInvGroup;
         this.viewItemsCmd = viewItemsCmd;
+        this.dashboardCmd = dashboardCmd;
 
         setCommandData(Commands.slash("mods", "Commands for the moderators of Lemi the discord bot.")
                 .addSubcommands(
@@ -63,7 +65,9 @@ public class ModsTopLevel extends SlashCmd {
                                 .addOptions(this.addCurrProfileCmd.getOptions()),
 
                         new SubcommandData(this.viewItemsCmd.getName(), this.viewItemsCmd.getDesc())
-                                .addOptions(this.viewItemsCmd.getOptions())
+                                .addOptions(this.viewItemsCmd.getOptions()),
+
+                        new SubcommandData(this.dashboardCmd.getName(), this.dashboardCmd.getDesc())
                 )
                 .addSubcommandGroups(
                         new SubcommandGroupData(this.modifyBalGroup.getName(), this.modifyBalGroup.getDesc())
@@ -117,6 +121,10 @@ public class ModsTopLevel extends SlashCmd {
 
                 case "viewitems":
                     this.viewItemsCmd.action(event);
+                    break;
+
+                case "dashboard":
+                    this.dashboardCmd.action(event);
             }
         }
     }    


### PR DESCRIPTION
## 🍙 Pull Request Etiquette

- [x] I have checked the PRs and branches for this feature/bug fix.
- [x] I have read the [contributing manual](https://github.com/honiism/lemi-bot/wiki/Contributing)

## 🎀 Changes

### 🍰 Description
Added dashboard command for moderators (`/mods dashboard`). This command will show the memory info, OS info, CPU info, and uptime info of Lemi.

### 🌷 Details
- Added OSHI library to view CPU information.
- Removed unnecessary dependencies.
- Added dashboard command.
- Registered dashboard command.
- Closes issue: N/A (for this [card](https://github.com/honiism/lemi-bot/projects/1#card-78524230)).

![image](https://user-images.githubusercontent.com/91908168/156600440-ca8c929a-e65a-4e13-9a06-362a47d730fb.png)